### PR TITLE
remove sdm: hwc2: Implement {get,set}ActiveConfig and fix for DRS

### DIFF
--- a/repo_update.sh
+++ b/repo_update.sh
@@ -55,7 +55,6 @@ popd
 pushd $ANDROOT/hardware/qcom/display
 LINK=$HTTP && LINK+="://android.googlesource.com/platform/hardware/qcom/display"
 git fetch $LINK refs/changes/35/437235/1 && git cherry-pick FETCH_HEAD
-git fetch $LINK refs/changes/83/573183/1 && git cherry-pick FETCH_HEAD
 git fetch $LINK refs/changes/42/576642/1 && git cherry-pick FETCH_HEAD
 popd
 


### PR DESCRIPTION
This patch breaks HWC2 and will be removed for now

Signed-off-by: Alin Jerpelea <alin.jerpelea@sony.com>